### PR TITLE
Update SpinalHDL to 1.14.2 and add Carbon platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-val spinalVersion = "1.13.0"
+val spinalVersion = "1.14.2"
 
 lazy val root = (project in file("."))
   .settings(

--- a/hardware/scala/elements/board/ElemRVFlask.scala
+++ b/hardware/scala/elements/board/ElemRVFlask.scala
@@ -28,6 +28,20 @@ object ElemRVFlask {
     }
   }
 
+  object Carbon {
+    val oscillatorFrequency = 50 MHz
+
+    case class Parameter(
+        kitParameter: KitParameter
+    ) extends BoardParameter(
+          kitParameter,
+          oscillatorFrequency
+        ) {
+      def getJtagFrequency = 10 MHz
+      override val sysconInfo = ElemRVFlask.sysconInfo
+    }
+  }
+
   object Nitrogen {
     val oscillatorFrequency = 60 MHz
 

--- a/hardware/scala/zibal/misc/ElementsConfig.scala
+++ b/hardware/scala/zibal/misc/ElementsConfig.scala
@@ -6,10 +6,37 @@ package zibal.misc
 
 import spinal.core._
 import spinal.core.sim._
+import spinal.core.internals.{MemTopology, PhaseMemBlackBoxingGeneric}
+import spinal.lib.blackbox.ihp.sg13g2.{IhpSramMacro, PhaseIhpSramBlackBox}
 
 import java.time.LocalDate
 
 object ElementsConfig {
+  class IhpSramBlackboxPolicy(macros: Seq[IhpSramMacro] = IhpSramMacro.defaults)
+      extends MemBlackboxingPolicy {
+    override def translationInterest(topology: MemTopology): Boolean = {
+      val depth = topology.mem.wordCount
+      val width = topology.mem.getWidth
+      val ports =
+        (topology.readWriteSync.size, topology.writes.size, topology.readsSync.size) match {
+          case (1, 0, 0) => 1
+          case (0, 1, 1) => 2
+          case _ => return false
+        }
+      macros.exists(m => m.ports == ports && m.depth == depth && m.width == width)
+    }
+
+    override def onUnblackboxable(topology: MemTopology, who: Any, message: String): Unit = {}
+  }
+
+  implicit class SpinalConfigPimp(config: SpinalConfig) {
+    def ihpSramBlackboxes: SpinalConfig = {
+      config.memBlackBoxers += new PhaseMemBlackBoxingGeneric(new IhpSramBlackboxPolicy())
+      config.memBlackBoxers += new PhaseIhpSramBlackBox()
+      config
+    }
+  }
+
   def apply(top: Object) = ElementsConfig(top)
   case class ElementsConfig(top: Object) {
     val socName = System.getenv("SOC")

--- a/hardware/scala/zibal/misc/ElementsConfig.scala
+++ b/hardware/scala/zibal/misc/ElementsConfig.scala
@@ -91,7 +91,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
     def genASICSimConfig = SimConfig
       .withConfig(this.genASICSpinalConfig)
       .withWave
-      .addSimulatorFlag("--trace-max-width 100000")
+      .addSimulatorFlag("--trace-max-width 100000 --Wno-SPECIFYIGN")
       .workspacePath(this.zibalBuildPath)
       .allOptimisation
   }

--- a/hardware/scala/zibal/misc/OpenROADTools.scala
+++ b/hardware/scala/zibal/misc/OpenROADTools.scala
@@ -57,6 +57,7 @@ object OpenROADTools {
       var pdnMetal5Pitch: Double = 40.0
       var pdnTopMetal1Pitch: Double = 60.0
       var pdnTopMetal2Pitch: Double = 60.0
+      val additionalVerilogFiles = ArrayBuffer[String]()
 
       val pads = Map(
         Edge.North -> Map[Int, String](),
@@ -101,7 +102,11 @@ object OpenROADTools {
           orientation: String = "R0",
           depth: Int = 2
       ) = {
-        val macroName = macroComp.getClass.toString().split('$')(1)
+        val macroName = if (macroComp.definitionName != null) {
+          macroComp.definitionName
+        } else {
+          macroComp.getClass.toString().split('$')(1)
+        }
         val compName = getCompName(macroComp).substring(1).split('.').takeRight(depth).mkString(".")
         macros += ((compName, macroName, x, y, orientation))
       }
@@ -602,7 +607,9 @@ object OpenROADTools {
           writer.write(s"export DESIGN_NICKNAME=${designName}\n");
         }
         writer.write(s"export PLATFORM=ihp-${platform.tech}\n");
-        writer.write(s"export VERILOG_FILES=${config.zibalBuildPath}*.v\n")
+        val verilogFiles =
+          (Seq(s"${config.zibalBuildPath}*.v") ++ additionalVerilogFiles).mkString(" ")
+        writer.write(s"export VERILOG_FILES=${verilogFiles}\n")
         writer.write(s"export DIE_AREA = ${dieArea._1} ${dieArea._2} ${dieArea._3} ${dieArea._4}\n")
         writer.write(
           s"export CORE_AREA = ${coreArea._1} ${coreArea._2} ${coreArea._3} ${coreArea._4}\n"

--- a/hardware/scala/zibal/platform/nonmetals/Carbon.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Carbon.scala
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package zibal.platform
+
+import spinal.core._
+import spinal.lib._
+
+import zibal.misc.BaremetalTools
+import zibal.misc.ElementsConfig
+import zibal.soc.SocParameter
+
+import spinal.lib.bus.misc.{SizeMapping, AddressMapping}
+import spinal.lib.bus.tilelink.{
+  Bus => TileLinkBus,
+  BusParameter => TileLinkParameter,
+  Arbiter,
+  Decoder,
+  DecoderDownSpec,
+  NodeParameters,
+  M2sParameters,
+  M2sSupport,
+  M2sTransfers,
+  SizeRange
+}
+import spinal.lib.system.tag.{MappedNode, MappedTransfers}
+
+import nafarr.bus.tilelink.TileLinkCache
+import nafarr.system.mtimer.{TileLinkMachineTimer, MachineTimerCtrl}
+import nafarr.system.plic.{TileLinkPlic, PlicCtrl}
+import nafarr.system.reset.{TileLinkResetController, ResetControllerCtrl}
+import nafarr.system.clock.{TileLinkClockController, ClockControllerCtrl}
+import nafarr.system.syscon.{TileLinkSyscon, Syscon}
+import nafarr.system.esm.{TileLinkEsm, EsmCtrl}
+import nafarr.{Vendor, Platform, PlatformClass, Feature}
+import nafarr.system.semaphore.{TileLinkSemaphore, SemaphoreCtrl}
+import nafarr.system.timer.{TileLinkTimer, TimerCtrl}
+import nafarr.system.watchdog.{TileLinkWatchdog, WatchdogCtrl}
+import nafarr.memory.spi.{TileLinkSpiXipController}
+import nafarr.memory.ocram.TileLinkOnChipRam
+import nafarr.peripherals.com.spi.{Spi, SpiControllerCtrl}
+import nafarr.cores.cpu.vexiiriscv.{VexiiRiscvCoreParameter, TileLinkVexiiRiscv}
+
+import spinal.lib.com.jtag.Jtag
+
+object Carbon {
+
+  case class Parameter(
+      socParameter: SocParameter,
+      onChipRamSize: BigInt,
+      spiRomSize: BigInt,
+      resetCtrl: (
+          ResetControllerCtrl.Parameter
+      ) => ResetControllerCtrl.ResetControllerBase,
+      clockCtrl: (
+          ClockControllerCtrl.Parameter,
+          ResetControllerCtrl.ResetControllerBase
+      ) => ClockControllerCtrl.ClockControllerBase,
+      hasEsm: Boolean = true,
+      onChipRamLogic: (TileLinkParameter, BigInt) => (Component, TileLinkBus) =
+        (p: TileLinkParameter, size: BigInt) => {
+          val ram = TileLinkOnChipRam(p = p, size = size)
+          (ram, ram.io.bus)
+        }
+  ) extends PlatformParameter(socParameter) {
+    val core = VexiiRiscvCoreParameter.realtime(
+      0xa0000000L,
+      iCacheSets = 32,
+      withMul = true,
+      withCompressed = true,
+      withBarrelShifter = true
+    )
+    val mtimer = MachineTimerCtrl.Parameter.default
+    val clocks = ClockControllerCtrl.Parameter(getKitParameter.clocks)
+    val resets = ResetControllerCtrl.Parameter(getKitParameter.resets)
+    def buildSyscon(features: List[Feature.E] = Nil) = Syscon.Parameter(
+      vendor = getBoardParameter.sysconInfo.vendor,
+      platform = Platform.Carbon,
+      platformClass = PlatformClass.NonMetal,
+      product = getBoardParameter.sysconInfo.product,
+      refClockHz =
+        getKitParameter.clocks.find(_.name == "system").map(_.frequency.toLong).getOrElse(0L),
+      siliconMajor = getBoardParameter.sysconInfo.siliconMajor,
+      siliconMinor = getBoardParameter.sysconInfo.siliconMinor,
+      features = features
+    )
+    val spi = SpiControllerCtrl.Parameter.xip()
+    val timer = TimerCtrl.Parameter.small()
+    val watchdog = WatchdogCtrl.Parameter.windowed()
+    val platformErrors = Seq(watchdog)
+    val esm = EsmCtrl.Parameter.small(getSocParameter.getErrorCount(platformErrors.size))
+    val platformIrqs = Seq(timer, watchdog, esm)
+    val plic = PlicCtrl.Parameter.default(getSocParameter.getInterruptCount(platformIrqs.size))
+  }
+
+  class Carbon(parameter: Parameter) extends PlatformComponent(parameter) {
+
+    // -----------------------------------------------------------------------
+    // Platform IO
+    // -----------------------------------------------------------------------
+    val io_plat = new Bundle {
+      val reset = in(Bool)
+      val clock = in(Bool)
+      val jtag = slave(Jtag())
+      val spi = master(Spi.Io(parameter.spi.io))
+    }
+
+    def prepareBaremetal(name: String, elementsConfig: ElementsConfig.ElementsConfig) {
+      val header = BaremetalTools.Header(elementsConfig, name)
+      header.generateTileLink(
+        this.system.periphMapping,
+        this.tileLinkMapping,
+        this.irqMapping,
+        this.errorMapping
+      )
+    }
+
+    override def initOnChipRam(path: String) {}
+
+    // -----------------------------------------------------------------------
+    // Reset and clock controllers
+    // -----------------------------------------------------------------------
+    val resetCtrl = parameter.resetCtrl(parameter.resets)
+    resetCtrl.io.mainReset := io_plat.reset
+    resetCtrl.io.mainClock := io_plat.clock
+    resetCtrl.io.trigger := 0
+
+    val clockCtrl = parameter.clockCtrl(parameter.clocks, resetCtrl)
+    ClockControllerCtrl.connect(parameter.clocks, clockCtrl, resetCtrl)
+    clockCtrl.io.mainReset := io_plat.reset
+    clockCtrl.io.mainClock := io_plat.clock
+
+    // -----------------------------------------------------------------------
+    // CPU (debug clock domain set explicitly; system CD from ClockingArea)
+    // -----------------------------------------------------------------------
+    val core = new ClockingArea(clockCtrl.getClockDomainByName("system")) {
+      val cpu = new TileLinkVexiiRiscv(
+        TileLinkVexiiRiscv.Parameter(
+          parameter.core.plugins,
+          parameter.core.iBusTlParam,
+          parameter.core.dBusTlParam
+        ),
+        clockCtrl.getClockDomainByName("debug")
+      )
+
+      clockCtrl.getClockDomainByName("debug") {
+        resetCtrl.triggerByNameWithCond("system", RegNext(cpu.ndmreset))
+      }
+
+      io_plat.jtag <> cpu.jtag
+    }
+
+    // -----------------------------------------------------------------------
+    // System interconnect — dual-decoder crossbar
+    //
+    //   iBus ──→ iDecoder ──┬──→ ocramArbiter ──→ OCRAM
+    //                       └──→ spiArbiter   ──→ SpiCache ──→ SpiXip
+    //
+    //   dBus ──→ dDecoder ──┬──→ ocramArbiter ─┘ (shared with iBus)
+    //                       ├──→ spiArbiter   ─┘ (shared with iBus)
+    //                       └──→ periphBus ──→ {PLIC, MTimer, ResetCtrl, …}
+    //
+    // iBus has no access to the peripheral bus (instruction fetches only).
+    // connectPeripherals() wires the peripheral decoder to all slave devices.
+    // -----------------------------------------------------------------------
+    val system = new ClockingArea(clockCtrl.getClockDomainByName("system")) {
+
+      val memParam = parameter.core.iBusTlParam // TL-UL, sourceWidth=1
+      val periphParam = TileLinkParameter.simple(32, 32, memParam.sizeBytes, 1)
+
+      // NodeParameters matching the CPU's TL-UL bus
+      val memNode = NodeParameters(
+        M2sParameters(
+          M2sSupport(
+            transfers = M2sTransfers(
+              get = SizeRange.upTo(memParam.sizeBytes),
+              putFull = SizeRange.upTo(memParam.sizeBytes),
+              putPartial = SizeRange.upTo(memParam.sizeBytes)
+            ),
+            addressWidth = memParam.addressWidth,
+            dataWidth = memParam.dataWidth
+          ),
+          1 << memParam.sourceWidth
+        )
+      )
+
+      def downSpec(mapping: SizeMapping): DecoderDownSpec = {
+        val transfers = M2sTransfers(
+          get = SizeRange.upTo(memParam.sizeBytes),
+          putFull = SizeRange.upTo(memParam.sizeBytes),
+          putPartial = SizeRange.upTo(memParam.sizeBytes)
+        )
+        DecoderDownSpec(
+          mappeds = List(
+            MappedTransfers(
+              MappedNode(Component.current, mapping, Nil),
+              transfers
+            )
+          ),
+          transformers = Nil,
+          nodeParam = memNode
+        )
+      }
+
+      // -----------------------------------------------------------------------
+      // Address mappings
+      // -----------------------------------------------------------------------
+      val ocramMapping = SizeMapping(0x80000000L, parameter.onChipRamSize)
+      val spiMapping = SizeMapping(0xa0000000L, parameter.spiRomSize)
+      val periphMapping = SizeMapping(0xf0000000L, 16 MB)
+
+      // -----------------------------------------------------------------------
+      // Memory bus decoders (iBus → 2 slaves, dBus → 3 slaves)
+      // -----------------------------------------------------------------------
+      val iBusDecoder = Decoder(memNode, Seq(downSpec(ocramMapping), downSpec(spiMapping)))
+      val dBusDecoder =
+        Decoder(memNode, Seq(downSpec(ocramMapping), downSpec(spiMapping), downSpec(periphMapping)))
+
+      iBusDecoder.io.up <> core.cpu.iBus
+      dBusDecoder.io.up <> core.cpu.dBus
+
+      // -----------------------------------------------------------------------
+      // Arbiters: combine iBus and dBus paths for OCRAM and SpiXip
+      // -----------------------------------------------------------------------
+      val arbiterDownNode = Arbiter.downNodeFrom(Seq(memNode, memNode))
+      val ocramArbiter = Arbiter(Seq(memNode, memNode), arbiterDownNode)
+      val spiArbiter = Arbiter(Seq(memNode, memNode), arbiterDownNode)
+
+      iBusDecoder.io.downs(0) <> ocramArbiter.io.ups(0)
+      dBusDecoder.io.downs(0) <> ocramArbiter.io.ups(1)
+
+      iBusDecoder.io.downs(1) <> spiArbiter.io.ups(0)
+      dBusDecoder.io.downs(1) <> spiArbiter.io.ups(1)
+
+      // -----------------------------------------------------------------------
+      // OCRAM (Arbiter output: sourceWidth = memParam.sourceWidth + 1)
+      // -----------------------------------------------------------------------
+      val onChipRam = new Area {
+        val mapping = ocramMapping
+        val busParam = ocramArbiter.io.down.p
+        val (ctrl, port) = parameter.onChipRamLogic(busParam, mapping.size)
+        port <> ocramArbiter.io.down
+      }
+
+      // -----------------------------------------------------------------------
+      // SPI XIP controller with a 4-word cache
+      // -----------------------------------------------------------------------
+      val spiXip = new Area {
+        val mapping = spiMapping
+        val busParam = spiArbiter.io.down.p
+
+        val ctrl = TileLinkSpiXipController(parameter.spi, busParam)
+        ctrl.io.bus <> spiArbiter.io.down
+        io_plat.spi <> ctrl.io.spi
+      }
+
+      // -----------------------------------------------------------------------
+      // Peripheral bus (Port 2): dBus → peripheral decoder
+      // Published so that connectPeripherals() can wire the peripherals.
+      // -----------------------------------------------------------------------
+      val periphBusPort = TileLinkBus(periphParam)
+      dBusDecoder.io.downs(2) <> periphBusPort
+
+      // -----------------------------------------------------------------------
+      // System peripherals
+      // -----------------------------------------------------------------------
+      val plicCtrl = TileLinkPlic(parameter.plic)
+      core.cpu.globalInterrupt := plicCtrl.io.interrupt
+      addPeripheralDevice(plicCtrl.io.bus, 0x800000, 4 MB)
+
+      val mtimerCtrl = TileLinkMachineTimer(parameter.mtimer)
+      core.cpu.mtimerInterrupt := mtimerCtrl.io.interrupt
+      addPeripheralDevice(mtimerCtrl.io.bus, 0x20000, 4 kB)
+
+      val resetCtrlMapper = TileLinkResetController(parameter.resets)
+      resetCtrlMapper.io.config <> resetCtrl.io.config
+      addPeripheralDevice(resetCtrlMapper.io.bus, 0x21000, 4 kB)
+
+      val clockCtrlMapper = TileLinkClockController(parameter.clocks)
+      clockCtrlMapper.io.config <> clockCtrl.io.config
+      addPeripheralDevice(clockCtrlMapper.io.bus, 0x22000, 4 kB)
+
+      addPeripheralDevice(spiXip.ctrl.io.cfgSpiBus, 0x24000, 4 kB)
+      addPeripheralDevice(spiXip.ctrl.io.cfgXipBus, 0x25000, 4 kB)
+
+      val timerCtrlMapper = TileLinkTimer(parameter.timer)
+      addPeripheralDevice(timerCtrlMapper.io.bus, 0x26000, 4 kB)
+      addInterrupt(timerCtrlMapper.io.interrupt)
+
+      val watchdogCtrlMapper = TileLinkWatchdog(parameter.watchdog)
+      addPeripheralDevice(watchdogCtrlMapper.io.bus, 0x27000, 4 kB)
+      addInterrupt(watchdogCtrlMapper.io.interrupt)
+      addError(watchdogCtrlMapper.io.error)
+
+      val (esmInterrupt: Bool, esmError: Bool) = if (parameter.hasEsm) {
+        val esmCtrlMapper = TileLinkEsm(parameter.esm)
+        addPeripheralDevice(esmCtrlMapper.io.bus, 0x28000, 4 kB)
+        publishEsm(esmCtrlMapper)
+        (
+          esmCtrlMapper.io.infoInterrupt || esmCtrlMapper.io.warnInterrupt,
+          esmCtrlMapper.io.errorSignal
+        )
+      } else {
+        (False, False)
+      }
+      addInterrupt(esmInterrupt)
+      resetCtrl.triggerByNameWithCond("system", esmError)
+      resetCtrl.triggerByNameWithCond("debug", esmError)
+
+      val sysconCtrlMapper = TileLinkSyscon(parameter.buildSyscon(getSysconFeatures()))
+      addPeripheralDevice(sysconCtrlMapper.io.bus, 0x23000, 4 kB)
+
+      publishPeripheralComponents(periphBusPort, 0xf0000000L, plicCtrl)
+    }
+  }
+}

--- a/hardware/scala/zibal/platform/nonmetals/Carbon.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Carbon.scala
@@ -49,7 +49,8 @@ object Carbon {
   case class Parameter(
       socParameter: SocParameter,
       onChipRamSize: BigInt,
-      spiRomSize: BigInt,
+      spiFlashSize: BigInt,
+      iCacheSize: BigInt,
       resetCtrl: (
           ResetControllerCtrl.Parameter
       ) => ResetControllerCtrl.ResetControllerBase,
@@ -66,7 +67,7 @@ object Carbon {
   ) extends PlatformParameter(socParameter) {
     val core = VexiiRiscvCoreParameter.realtime(
       0xa0000000L,
-      iCacheSets = 32,
+      iCacheSize = iCacheSize,
       withMul = true,
       withCompressed = true,
       withBarrelShifter = true
@@ -207,7 +208,7 @@ object Carbon {
       // Address mappings
       // -----------------------------------------------------------------------
       val ocramMapping = SizeMapping(0x80000000L, parameter.onChipRamSize)
-      val spiMapping = SizeMapping(0xa0000000L, parameter.spiRomSize)
+      val spiMapping = SizeMapping(0xa0000000L, parameter.spiFlashSize)
       val periphMapping = SizeMapping(0xf0000000L, 16 MB)
 
       // -----------------------------------------------------------------------

--- a/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
@@ -49,7 +49,7 @@ object Hydrogen {
   case class Parameter(
       socParameter: SocParameter,
       onChipRamSize: BigInt,
-      spiRomSize: BigInt,
+      spiFlashSize: BigInt,
       resetCtrl: (
           ResetControllerCtrl.Parameter
       ) => ResetControllerCtrl.ResetControllerBase,
@@ -201,7 +201,7 @@ object Hydrogen {
       // Address mappings
       // -----------------------------------------------------------------------
       val ocramMapping = SizeMapping(0x80000000L, parameter.onChipRamSize)
-      val spiMapping = SizeMapping(0xa0000000L, parameter.spiRomSize)
+      val spiMapping = SizeMapping(0xa0000000L, parameter.spiFlashSize)
       val periphMapping = SizeMapping(0xf0000000L, 16 MB)
 
       // -----------------------------------------------------------------------

--- a/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
@@ -161,7 +161,7 @@ object Hydrogen {
     val system = new ClockingArea(clockCtrl.getClockDomainByName("system")) {
 
       val memParam = parameter.core.iBusTlParam // TL-UL, sourceWidth=1
-      val periphParam = TileLinkParameter.simple(32, 32, 4, 1)
+      val periphParam = TileLinkParameter.simple(32, 32, memParam.sizeBytes, 1)
 
       // NodeParameters matching the CPU's TL-UL bus
       val memNode = NodeParameters(

--- a/hardware/scala/zibal/platform/nonmetals/Nitrogen.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Nitrogen.scala
@@ -37,7 +37,7 @@ object Nitrogen {
   case class Parameter(
       socParameter: SocParameter,
       onChipRamSize: BigInt,
-      spiRomSize: BigInt,
+      spiFlashSize: BigInt,
       hyperbusPartitions: List[(BigInt, Boolean)],
       resetCtrl: (
           ResetControllerCtrl.Parameter
@@ -215,7 +215,7 @@ object Nitrogen {
     }
 
     val spiXip = new ClockingArea(clockCtrl.getClockDomainByName("spiXip")) {
-      val mapping = SizeMapping(0xa0000000L, parameter.spiRomSize)
+      val mapping = SizeMapping(0xa0000000L, parameter.spiFlashSize)
       val bmbParameter = BmbParameter(
         addressWidth = log2Up(mapping.size) + 2,
         dataWidth = 32,

--- a/hardware/scala/zibal/sim/MT25Q.scala
+++ b/hardware/scala/zibal/sim/MT25Q.scala
@@ -66,10 +66,8 @@ object MT25Q {
 
     val chipClockDomain = ClockDomain(
       clock = io.dataClock,
-      reset = io.reset,
       config = ClockDomainConfig(
-        resetKind = ASYNC,
-        resetActiveLevel = LOW
+        resetKind = BOOT
       )
     )
 


### PR DESCRIPTION
  - Bump SpinalHDL dependency from 1.13.0 to 1.14.2
  - Add the Carbon nonmetal platform with VexiiRiscv realtime core, dual-decoder TileLink crossbar, and standard peripherals
  - Fix Hydrogen peripheral bus size to use dynamic memParam.sizeBytes instead of a hardcoded value
  - Add IHP SG13G2 SRAM blackboxing policy for automatic memory macro replacement during elaboration
  - Support additional Verilog files and improve macro naming in OpenROAD tooling