### PR TITLE
hardware: zibal: platform: nonmetals: Use inputClock

### DIFF
--- a/hardware/scala/zibal/package.scala
+++ b/hardware/scala/zibal/package.scala
@@ -14,7 +14,8 @@ import nafarr.{Product, Vendor, Feature}
 package object board {
   case class KitParameter(
       resets: List[ResetParameter],
-      clocks: List[ClockParameter]
+      clocks: List[ClockParameter],
+      inputClock: ClockParameter
   )
 
   /** Board-level chip identity forwarded to the syscon IP.

--- a/hardware/scala/zibal/platform/nonmetals/Carbon.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Carbon.scala
@@ -73,15 +73,17 @@ object Carbon {
       withBarrelShifter = true
     )
     val mtimer = MachineTimerCtrl.Parameter.default
-    val clocks = ClockControllerCtrl.Parameter(getKitParameter.clocks)
+    val clocks = ClockControllerCtrl.Parameter(
+      getKitParameter.clocks,
+      getKitParameter.inputClock
+    )
     val resets = ResetControllerCtrl.Parameter(getKitParameter.resets)
     def buildSyscon(features: List[Feature.E] = Nil) = Syscon.Parameter(
       vendor = getBoardParameter.sysconInfo.vendor,
       platform = Platform.Carbon,
       platformClass = PlatformClass.NonMetal,
       product = getBoardParameter.sysconInfo.product,
-      refClockHz =
-        getKitParameter.clocks.find(_.name == "system").map(_.frequency.toLong).getOrElse(0L),
+      refClockHz = getKitParameter.inputClock.frequency.toLong,
       siliconMajor = getBoardParameter.sysconInfo.siliconMajor,
       siliconMinor = getBoardParameter.sysconInfo.siliconMinor,
       features = features

--- a/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Hydrogen.scala
@@ -66,15 +66,17 @@ object Hydrogen {
   ) extends PlatformParameter(socParameter) {
     val core = VexiiRiscvCoreParameter.realtime(0xa0000000L)
     val mtimer = MachineTimerCtrl.Parameter.default
-    val clocks = ClockControllerCtrl.Parameter(getKitParameter.clocks)
+    val clocks = ClockControllerCtrl.Parameter(
+      getKitParameter.clocks,
+      getKitParameter.inputClock
+    )
     val resets = ResetControllerCtrl.Parameter(getKitParameter.resets)
     def buildSyscon(features: List[Feature.E] = Nil) = Syscon.Parameter(
       vendor = getBoardParameter.sysconInfo.vendor,
       platform = Platform.Hydrogen,
       platformClass = PlatformClass.NonMetal,
       product = getBoardParameter.sysconInfo.product,
-      refClockHz =
-        getKitParameter.clocks.find(_.name == "system").map(_.frequency.toLong).getOrElse(0L),
+      refClockHz = getKitParameter.inputClock.frequency.toLong,
       siliconMajor = getBoardParameter.sysconInfo.siliconMajor,
       siliconMinor = getBoardParameter.sysconInfo.siliconMinor,
       features = features

--- a/hardware/scala/zibal/platform/nonmetals/Nitrogen.scala
+++ b/hardware/scala/zibal/platform/nonmetals/Nitrogen.scala
@@ -58,7 +58,10 @@ object Nitrogen {
     val core = VexRiscvCoreParameter.mcu(0xa0000000L, 1024, 1024).plugins
     val mtimer = MachineTimerCtrl.Parameter.default
     val plic = PlicCtrl.Parameter.default(getSocParameter.getInterruptCount(0))
-    val clocks = ClockControllerCtrl.Parameter(getKitParameter.clocks)
+    val clocks = ClockControllerCtrl.Parameter(
+      getKitParameter.clocks,
+      getKitParameter.inputClock
+    )
     val resets = ResetControllerCtrl.Parameter(getKitParameter.resets)
     val hyperbus = HyperBusCtrl.Parameter.default(hyperbusPartitions)
     val spi = SpiControllerCtrl.Parameter.xip()


### PR DESCRIPTION
Use the inputClock value as reference clock for syscon and pass it to the ClockController to calculate the multiple/divider value.